### PR TITLE
Extend

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,2 @@
+:l TDParseCFG.hs TDPretty.hs Lambda_calc.lhs TDDemo.hs
+:m + TDParseCFG TDPretty Lambda_calc TDDemo


### PR DESCRIPTION
XL is a little meta-op that additionally extends any op set to swallow a comonadic value. Eps has this property, since its left argument is guaranteed to be comonadic. Extending it just means that refs get regenerated upon meeting their anaphors. Without this rule [binder left and pro saw pro] has a double-bound reading, since the pros can combine with A, but [binder saw pro and pro left] does not have this reading because the binder has to make a choice when it meets the first pro. But with the X rule, both configurations have a (unique) double-bound derivation.